### PR TITLE
Add project rename to UI and backend; fix class add after import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -198,6 +198,22 @@ def restore_project(project_id: str, user=Depends(get_user)):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@app.put("/api/projects/{project_id}")
+def rename_project(project_id: str, body: Dict, user=Depends(get_user)):
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Name required")
+    try:
+        if not db.is_user_member(project_id=project_id, user_id=user["user_id"]):
+            raise HTTPException(status_code=403, detail="Not a member of project")
+        proj = db.rename_project(project_id=project_id, new_name=name)
+        return {"project": proj}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @app.on_event("startup")
 async def on_startup():
     # Ensure services are initialized lazily via Settings

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -293,6 +293,7 @@
       </aside>
       <!-- Project context menu -->
       <div id="projectContextMenu" style="position:absolute; display:none; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding:4px; z-index: 9999; min-width: 220px;">
+        <button id="projRenameBtn" class="btn" style="width:100%; text-align:left; background:none; border:none; padding:8px; color:var(--text);">Rename Project…</button>
         <button id="projArchiveBtn" class="btn" style="width:100%; text-align:left; background:none; border:none; padding:8px; color:var(--text);">Archive Project</button>
         <button id="projDeleteBtn" class="btn" style="width:100%; text-align:left; background:none; border:none; padding:8px; color:#ef4444;">Delete Project</button>
         <hr style="border:none; border-top:1px solid var(--border); margin:6px 0;"/>
@@ -1324,6 +1325,25 @@
       cmState.sourceId = null;
     }
 
+    // Ensure new class IDs do not collide with existing nodes after imports/loads
+    function recomputeNextId() {
+      try {
+        if (!ontoState || !ontoState.cy) return;
+        let maxNum = 0;
+        ontoState.cy.nodes().forEach(n => {
+          try {
+            const nid = (n && typeof n.id === 'function') ? n.id() : '';
+            const m = /^Class(\d+)$/.exec(String(nid || ''));
+            if (m) {
+              const num = parseInt(m[1], 10);
+              if (!isNaN(num)) maxNum = Math.max(maxNum, num);
+            }
+          } catch(_) {}
+        });
+        ontoState.nextId = Math.max(1, maxNum + 1);
+      } catch(_) {}
+    }
+
     function importOntologyJSON(obj) {
       ensureOntologyInitialized();
       if (!obj || !Array.isArray(obj.nodes) || !Array.isArray(obj.edges)) return;
@@ -1355,6 +1375,8 @@
       ontoState.cy.fit();
       refreshOntologyTree();
       persistOntologyToLocalStorage();
+      // Update ID counter so new classes get unique IDs
+      recomputeNextId();
     }
 
     // Auth/UI gating
@@ -1831,6 +1853,25 @@
             const archiveBtn = qs('#projArchiveBtn');
             const deleteBtn = qs('#projDeleteBtn');
             const showArchivedBtn = qs('#projShowArchivedBtn');
+            const renameBtn = qs('#projRenameBtn');
+            if (renameBtn) renameBtn.onclick = async () => {
+              try {
+                const currentName = (project && (project.name || '')) || '';
+                const newName = prompt('Rename project', currentName);
+                if (!newName || newName.trim() === currentName) return;
+                const res = await fetch(`/api/projects/${encodeURIComponent(pid)}`, {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + token },
+                  body: JSON.stringify({ name: newName.trim() })
+                });
+                if (res.ok) {
+                  await loadProjects();
+                } else {
+                  const t = await res.text().catch(()=>String(res.status));
+                  alert('Rename failed: ' + t);
+                }
+              } finally { hide(); }
+            };
             if (archiveBtn) archiveBtn.onclick = async () => {
               try {
                 const res = await fetch(`/api/projects/${encodeURIComponent(pid)}/archive`, { method: 'POST', headers: { Authorization: 'Bearer ' + token }});
@@ -2284,6 +2325,8 @@
         ontoState.cy.elements().remove();
         ontoState.cy.add(data.nodes || []);
         ontoState.cy.add(data.edges || []);
+        // After loading, ensure nextId is advanced beyond existing ClassNNN
+        recomputeNextId();
         requestAnimationFrame(()=>{ ontoState.cy.fit(); });
       } catch(_) {}
     }


### PR DESCRIPTION
- Frontend: Added "Rename Project…" to project context menu and handler calling PUT /api/projects/{id}
- Backend: Added PUT /api/projects/{id} to rename, plus DB rename_project
- Ontology workbench: Recompute nextId after import/load to avoid node ID collisions when adding new classes