### PR TITLE
fix: Improve ontology layout persistence and prevent system hangs

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -6747,10 +6747,54 @@
         }
         persistOntologyToLocalStorage();
       });
-      // Bind autosave on edits (add/remove/data/position)
+      // Bind autosave on edits (add/remove/data) - NOT position changes
       try {
         const autosave = debounce(() => { try { if (activeOntologyIri) persistOntologyToLocalStorage(); } catch (_) { } }, 250);
-        ontoState.cy.on('add remove data position', autosave);
+        ontoState.cy.on('add remove data', autosave);  // Removed 'position' event
+
+        // Create a separate debounced save for layout changes with longer delay
+        const layoutSave = debounce(() => {
+          try {
+            if (activeOntologyIri) {
+              console.log('🔄 Layout save triggered after 5 second delay');
+              const nodes = ontoState.cy.nodes().filter(n => !n.hasClass('imported')).map(n => ({ data: n.data(), position: n.position() }));
+              const edges = ontoState.cy.edges().filter(e => !e.hasClass('imported')).map(e => ({ data: e.data() }));
+              saveLayoutToServer(activeOntologyIri, nodes, edges);
+            }
+          } catch (_) { }
+        }, 5000); // 5 second delay for layout saves
+
+        // Create a fast debounced save for localStorage (100ms) to prevent excessive writes
+        const localStorageSave = debounce(() => {
+          try {
+            if (activeOntologyIri) {
+              persistOntologyToLocalStorage();
+
+              // Also save layout to localStorage for quick recovery
+              const pan = ontoState.cy.pan();
+              const zoom = ontoState.cy.zoom();
+              const nodes = ontoState.cy.nodes().filter(n => !n.hasClass('imported')).map(n => ({
+                iri: n.data('id'),
+                x: n.position('x'),
+                y: n.position('y')
+              }));
+
+              const layoutData = {
+                nodes: nodes,
+                zoom: zoom,
+                pan: pan,
+                timestamp: Date.now()
+              };
+
+              const localLayoutKey = `onto_layout_${encodeURIComponent(activeOntologyIri)}`;
+              localStorage.setItem(localLayoutKey, JSON.stringify(layoutData));
+              console.log('💾 Layout saved to localStorage');
+            }
+          } catch (_) { }
+        }, 100); // Very short delay - just to batch rapid movements
+
+        ontoState.cy.on('position', layoutSave);
+        ontoState.cy.on('position', localStorageSave); // Also save to localStorage quickly
         ontoState.autosaveBound = true;
 
         // Update modification metadata when elements are moved
@@ -13503,8 +13547,8 @@ ${insertParts.join('\\n')}
           };
           localStorage.setItem(storageKeyForGraph(activeOntologyIri), JSON.stringify(storageData));
 
-          // Also save layout data to server
-          saveLayoutToServer(activeOntologyIri, nodes, edges);
+          // Layout is now saved separately with its own debounced handler
+          // No longer automatically saving layout here to prevent excessive server calls
         }
       } catch (_) { }
     }
@@ -13559,6 +13603,41 @@ ${insertParts.join('\\n')}
 
     async function loadLayoutFromServer(graphIri) {
       try {
+        // First check if we have a recent layout in localStorage
+        const localLayoutKey = `onto_layout_${encodeURIComponent(graphIri)}`;
+        const localLayout = localStorage.getItem(localLayoutKey);
+
+        if (localLayout) {
+          try {
+            const layoutData = JSON.parse(localLayout);
+            // Check if local layout is recent (within last 30 seconds)
+            if (layoutData.timestamp && (Date.now() - layoutData.timestamp) < 30000) {
+              console.log('📍 Using recent layout from localStorage (saved within last 30 seconds)');
+
+              // Apply node positions from local storage
+              if (layoutData.nodes) {
+                layoutData.nodes.forEach(nodeLayout => {
+                  const node = ontoState.cy.$(`#${nodeLayout.iri}`);
+                  if (node.length > 0) {
+                    node.position({ x: nodeLayout.x, y: nodeLayout.y });
+                  }
+                });
+              }
+
+              // Apply zoom and pan
+              if (layoutData.zoom && layoutData.pan) {
+                ontoState.cy.zoom(layoutData.zoom);
+                ontoState.cy.pan(layoutData.pan);
+              }
+
+              return true;
+            }
+          } catch (e) {
+            console.warn('Error parsing local layout:', e);
+          }
+        }
+
+        // If no recent local layout, load from server
         const response = await authenticatedFetch(`/api/ontology/layout?graph=${encodeURIComponent(graphIri)}`);
 
         if (response.ok) {


### PR DESCRIPTION
## Description
This PR fixes system hangs when rapidly moving nodes in the Ontology Workbench and ensures layout changes persist across page refreshes.

## Problems Fixed
1. **System hangs** - Every node position change triggered immediate server saves with only 250ms debounce
2. **Lost layout changes** - Refreshing the page before server save completed would lose all position changes
3. **Server overload** - Rapid node movements caused excessive API calls

## Solution
- Separated layout saves from data saves to prevent excessive server calls
- Added 5-second debounce for server layout saves (was 250ms)
- Added 100ms debounced localStorage saves for immediate persistence
- Modified layout loading to check localStorage first for recent changes (within 30 seconds)

## Result
- No more system hangs when moving multiple nodes quickly
- Layout changes persist immediately even if you refresh before server save
- Significantly reduced server load during editing sessions